### PR TITLE
Updated module configuration

### DIFF
--- a/app/etc/modules/Mtgox_Bitcoin.xml
+++ b/app/etc/modules/Mtgox_Bitcoin.xml
@@ -9,7 +9,7 @@
     <modules>
         <Mtgox_Bitcoin>
             <active>true</active>
-            <codePool>local</codePool>
+            <codePool>community</codePool>
         </Mtgox_Bitcoin>
     </modules>
 </config>


### PR DESCRIPTION
The module configuration was still set as `local` instead of `community`, explains why the module didn't show up.
